### PR TITLE
Adam dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm run ui
 ### Debian/Ubuntu (apt)
 
 ```console
-# apt install pkg-config libxcb-dev libxcb-shm-dev libxcb-composite-dev libxcb-ewmh-dev libprocps-dev
+# apt install pkg-config libxcb-dev libxcb-shm-dev libxcb-composite-dev libxcb-ewmh-dev libxcb-record-dev libprocps-dev
 ```
 
 ### Gentoo (portage)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm run ui
 ### Debian/Ubuntu (apt)
 
 ```console
-# apt install pkg-config libxcb-dev libxcb-shm-dev libxcb-composite-dev libxcb-ewmh-dev libxcb-record-dev libprocps-dev
+# apt install pkg-config libxcb-dev libxcb-shm-dev libxcb-composite-dev libxcb-ewmh-dev libxcb-record-dev libxcb-shape-dev libprocps-dev
 ```
 
 ### Gentoo (portage)

--- a/binding.gyp
+++ b/binding.gyp
@@ -62,6 +62,7 @@
 						'<!@(<(pkg-config) --cflags xcb-ewmh)',
 						'<!@(<(pkg-config) --cflags xcb-shm)',
 						'<!@(<(pkg-config) --cflags xcb-composite)',
+						'<!@(<(pkg-config) --cflags xcb-record)',
 						'<!@(<(pkg-config) --cflags libprocps)'
 					],
 					'ldflags': [
@@ -69,6 +70,7 @@
 						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb-ewmh)',
 						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb-shm)',
 						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb-composite)',
+						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb-record)',
 						'<!@(<(pkg-config) --libs-only-L --libs-only-other libprocps)'
 					],
 					'libraries': [
@@ -76,6 +78,7 @@
 						'<!@(<(pkg-config) --libs-only-l xcb-ewmh)',
 						'<!@(<(pkg-config) --libs-only-l xcb-shm)',
 						'<!@(<(pkg-config) --libs-only-l xcb-composite)',
+						'<!@(<(pkg-config) --libs-only-l xcb-record)',
 						'<!@(<(pkg-config) --libs-only-l libprocps)'
 					],
 					"cflags_cc": [ "-std=c++17" ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -63,6 +63,7 @@
 						'<!@(<(pkg-config) --cflags xcb-shm)',
 						'<!@(<(pkg-config) --cflags xcb-composite)',
 						'<!@(<(pkg-config) --cflags xcb-record)',
+						'<!@(<(pkg-config) --cflags xcb-shape)',
 						'<!@(<(pkg-config) --cflags libprocps)'
 					],
 					'ldflags': [
@@ -71,6 +72,7 @@
 						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb-shm)',
 						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb-composite)',
 						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb-record)',
+						'<!@(<(pkg-config) --libs-only-L --libs-only-other xcb-shape)',
 						'<!@(<(pkg-config) --libs-only-L --libs-only-other libprocps)'
 					],
 					'libraries': [
@@ -79,6 +81,7 @@
 						'<!@(<(pkg-config) --libs-only-l xcb-shm)',
 						'<!@(<(pkg-config) --libs-only-l xcb-composite)',
 						'<!@(<(pkg-config) --libs-only-l xcb-record)',
+						'<!@(<(pkg-config) --libs-only-l xcb-shape)',
 						'<!@(<(pkg-config) --libs-only-l libprocps)'
 					],
 					"cflags_cc": [ "-std=c++17" ],

--- a/native/jsapi.h
+++ b/native/jsapi.h
@@ -88,12 +88,13 @@ void SetWindowParent(const Napi::CallbackInfo& info) {
 
 void SetWindowShape(const Napi::CallbackInfo& info) {
 	auto arr = info[1].As<Napi::Array>();
+	uint8_t op = static_cast<uint8_t>(info[2].As<Napi::Number>().Int32Value());
 	std::vector<JSRectangle> rects;
 	rects.reserve(arr.Length());
 	for(uint32_t i = 0; i < arr.Length(); i++) {
 		rects.push_back(JSRectangle::FromJsValue(arr[i]));
 	}
-	OSSetWindowShape(OSWindow::FromJsValue(info[0]), rects);
+	OSSetWindowShape(OSWindow::FromJsValue(info[0]), rects, op);
 }
 
 void UnsetWindowShape(const Napi::CallbackInfo& info) { OSUnsetWindowShape(OSWindow::FromJsValue(info[0])); }

--- a/native/jsapi.h
+++ b/native/jsapi.h
@@ -88,22 +88,19 @@ void SetWindowParent(const Napi::CallbackInfo& info) {
 
 void SetWindowShape(const Napi::CallbackInfo& info) {
 	auto arr = info[1].As<Napi::Array>();
-	uint8_t op = static_cast<uint8_t>(info[2].As<Napi::Number>().Int32Value());
 	std::vector<JSRectangle> rects;
 	rects.reserve(arr.Length());
 	for(uint32_t i = 0; i < arr.Length(); i++) {
 		rects.push_back(JSRectangle::FromJsValue(arr[i]));
 	}
-	OSSetWindowShape(OSWindow::FromJsValue(info[0]), rects, op);
+	OSSetWindowShape(OSWindow::FromJsValue(info[0]), rects);
 }
-
-void UnsetWindowShape(const Napi::CallbackInfo& info) { OSUnsetWindowShape(OSWindow::FromJsValue(info[0])); }
 
 void NewWindowListener(const Napi::CallbackInfo& info) {
 	auto wnd = OSWindow::FromJsValue(info[0]);
 	auto typestring = info[1].As<Napi::String>().Utf8Value();
 	Napi::Function cb = info[2].As<Napi::Function>();
-	auto typefind= windowEventTypes.find(typestring);
+	auto typefind = windowEventTypes.find(typestring);
 	if (typefind == windowEventTypes.end()) {
 		throw Napi::RangeError::New(info.Env(), "unknown event type");
 	}

--- a/native/jsapi.h
+++ b/native/jsapi.h
@@ -87,13 +87,17 @@ void SetWindowParent(const Napi::CallbackInfo& info) {
 }
 
 void SetWindowShape(const Napi::CallbackInfo& info) {
+#ifdef OS_LINUX
 	auto arr = info[1].As<Napi::Array>();
 	std::vector<JSRectangle> rects;
 	rects.reserve(arr.Length());
-	for(uint32_t i = 0; i < arr.Length(); i++) {
+	for (uint32_t i = 0; i < arr.Length(); i++) {
 		rects.push_back(JSRectangle::FromJsValue(arr[i]));
 	}
 	OSSetWindowShape(OSWindow::FromJsValue(info[0]), rects);
+#else
+	throw Napi::Error::New(info.Env(), "SetWindowShape is not implemented on this operating system");
+#endif
 }
 
 void NewWindowListener(const Napi::CallbackInfo& info) {

--- a/native/jsapi.h
+++ b/native/jsapi.h
@@ -86,6 +86,18 @@ void SetWindowParent(const Napi::CallbackInfo& info) {
 	OSSetWindowParent(wnd, parent);
 }
 
+void SetWindowShape(const Napi::CallbackInfo& info) {
+	auto arr = info[1].As<Napi::Array>();
+	std::vector<JSRectangle> rects;
+	rects.reserve(arr.Length());
+	for(uint32_t i = 0; i < arr.Length(); i++) {
+		rects.push_back(JSRectangle::FromJsValue(arr[i]));
+	}
+	OSSetWindowShape(OSWindow::FromJsValue(info[0]), rects);
+}
+
+void UnsetWindowShape(const Napi::CallbackInfo& info) { OSUnsetWindowShape(OSWindow::FromJsValue(info[0])); }
+
 void NewWindowListener(const Napi::CallbackInfo& info) {
 	auto wnd = OSWindow::FromJsValue(info[0]);
 	auto typestring = info[1].As<Napi::String>().Utf8Value();

--- a/native/lib.cc
+++ b/native/lib.cc
@@ -19,6 +19,8 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
 	exports.Set("getWindowTitle", Napi::Function::New(env, GetWindowTitle));
 	exports.Set("setWindowParent", Napi::Function::New(env, SetWindowParent));
 	exports.Set("getActiveWindow", Napi::Function::New(env, JSGetActiveWindow));
+	exports.Set("setWindowShape", Napi::Function::New(env, SetWindowShape));
+	exports.Set("unsetWindowShape", Napi::Function::New(env, UnsetWindowShape));
 
 	exports.Set("newWindowListener", Napi::Function::New(env, NewWindowListener));
 	exports.Set("removeWindowListener", Napi::Function::New(env, RemoveWindowListener));

--- a/native/lib.cc
+++ b/native/lib.cc
@@ -20,7 +20,6 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
 	exports.Set("setWindowParent", Napi::Function::New(env, SetWindowParent));
 	exports.Set("getActiveWindow", Napi::Function::New(env, JSGetActiveWindow));
 	exports.Set("setWindowShape", Napi::Function::New(env, SetWindowShape));
-	exports.Set("unsetWindowShape", Napi::Function::New(env, UnsetWindowShape));
 
 	exports.Set("newWindowListener", Napi::Function::New(env, NewWindowListener));
 	exports.Set("removeWindowListener", Napi::Function::New(env, RemoveWindowListener));

--- a/native/os.h
+++ b/native/os.h
@@ -98,3 +98,15 @@ void OSNewWindowListener(OSWindow wnd, WindowEventType type, Napi::Function cb);
  * Remove an event listener, wnd, type and cb must match
  */
 void OSRemoveWindowListener(OSWindow wnd, WindowEventType type, Napi::Function cb);
+
+/**
+ * Defines which region of a window can be clicked
+ * Implemented only on X11 Linux as a replacement for electron's setIgnoreMouseEvents()
+ */
+void OSSetWindowShape(OSWindow wnd, vector<JSRectangle> rects);
+
+/**
+ * Sets a window's clickable region back to default after calling OSSetWindowShape
+ * Implemented only on X11 Linux
+ */
+void OSUnsetWindowShape(OSWindow wnd);

--- a/native/os.h
+++ b/native/os.h
@@ -102,8 +102,9 @@ void OSRemoveWindowListener(OSWindow wnd, WindowEventType type, Napi::Function c
 /**
  * Defines which region of a window can be clicked
  * Implemented only on X11 Linux as a replacement for electron's setIgnoreMouseEvents()
+ * Op: 0=Set, 1=Union, 2=Intersect, 3=Subtract, 4=Invert - see Chapter 3 https://www.x.org/releases/X11R7.7/doc/xextproto/shape.html
  */
-void OSSetWindowShape(OSWindow wnd, vector<JSRectangle> rects);
+void OSSetWindowShape(OSWindow wnd, vector<JSRectangle> rects, uint8_t op);
 
 /**
  * Sets a window's clickable region back to default after calling OSSetWindowShape

--- a/native/os.h
+++ b/native/os.h
@@ -102,12 +102,5 @@ void OSRemoveWindowListener(OSWindow wnd, WindowEventType type, Napi::Function c
 /**
  * Defines which region of a window can be clicked
  * Implemented only on X11 Linux as a replacement for electron's setIgnoreMouseEvents()
- * Op: 0=Set, 1=Union, 2=Intersect, 3=Subtract, 4=Invert - see Chapter 3 https://www.x.org/releases/X11R7.7/doc/xextproto/shape.html
  */
-void OSSetWindowShape(OSWindow wnd, vector<JSRectangle> rects, uint8_t op);
-
-/**
- * Sets a window's clickable region back to default after calling OSSetWindowShape
- * Implemented only on X11 Linux
- */
-void OSUnsetWindowShape(OSWindow wnd);
+void OSSetWindowShape(OSWindow wnd, vector<JSRectangle> rects);

--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -278,7 +278,7 @@ void OSSetWindowShape(OSWindow window, std::vector<JSRectangle> rects, uint8_t o
 		xrects.push_back(rect);
 	}
 	uint8_t ordering = 0;
-	if (xrects.len() < 2) ordering = 3;
+	if (xrects.size() < 2) ordering = 3;
 	xcb_shape_rectangles(connection, op, 0, ordering, window.handle, 0, 0, xrects.size(), xrects.data());
 	xcb_flush(connection);
 }

--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -265,7 +265,8 @@ void IterateEvents(COND cond, F callback) {
 	condvars.clear();
 }
 
-void OSSetWindowShape(OSWindow window, std::vector<JSRectangle> rects) {
+void OSSetWindowShape(OSWindow window, std::vector<JSRectangle> rects, uint8_t op) {
+	OSUnsetWindowShape(window);
 	std::vector<xcb_rectangle_t> xrects;
 	xrects.reserve(rects.size());
 	for(size_t i = 0; i < rects.size(); i += 1) {
@@ -276,11 +277,14 @@ void OSSetWindowShape(OSWindow window, std::vector<JSRectangle> rects) {
 		rect.height = rects[i].height;
 		xrects.push_back(rect);
 	}
-	xcb_shape_rectangles(connection, 0, 0, 0, window.handle, 0, 0, xrects.size(), xrects.data());
+	uint8_t ordering = 0;
+	if (xrects.len() < 2) ordering = 3;
+	xcb_shape_rectangles(connection, op, 0, ordering, window.handle, 0, 0, xrects.size(), xrects.data());
 	xcb_flush(connection);
 }
 
 void OSUnsetWindowShape(OSWindow window) {
+	ensureConnection();
 	xcb_shape_mask(connection, 0, 0, window.handle, 0, 0, 0);
 }
 

--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -265,6 +265,25 @@ void IterateEvents(COND cond, F callback) {
 	condvars.clear();
 }
 
+void OSSetWindowShape(OSWindow window, std::vector<JSRectangle> rects) {
+	std::vector<xcb_rectangle_t> xrects;
+	xrects.reserve(rects.size());
+	for(size_t i = 0; i < rects.size(); i += 1) {
+		xcb_rectangle_t rect;
+		rect.x = rects[i].x;
+		rect.y = rects[i].y;
+		rect.width = rects[i].width;
+		rect.height = rects[i].height;
+		xrects.push_back(rect);
+	}
+	xcb_shape_rectangles(connection, 0, 0, 0, window.handle, 0, 0, xrects.size(), xrects.data());
+	xcb_flush(connection);
+}
+
+void OSUnsetWindowShape(OSWindow window) {
+	xcb_shape_mask(connection, 0, 0, window.handle, 0, 0, 0);
+}
+
 
 void OSNewWindowListener(OSWindow window, WindowEventType type, Napi::Function callback) {
 	auto event = TrackedEvent(window.handle, type, callback);

--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -582,10 +582,12 @@ void RecordThread() {
 					case XCB_BUTTON_PRESS: {
 						xcb_button_press_event_t* event = (xcb_button_press_event_t*)ev;
 						auto button = event->detail;
-						int16_t click_x = event->root_x;
-						int16_t click_y = event->root_y;
-						xcb_window_t hit = HitTest(click_x, click_y);
-						std::cout << "Clicked on window " << hit << std::endl;
+						if (button >= 1 && button <= 3) {
+							int16_t click_x = event->root_x;
+							int16_t click_y = event->root_y;
+							xcb_window_t hit = HitTest(click_x, click_y);
+							std::cout << "Clicked on window " << hit << std::endl;
+						}
 						break;
 					}
 					case XCB_BUTTON_RELEASE: {

--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -56,7 +56,7 @@ JSRectangle OSWindow::GetClientBounds() {
 		return JSRectangle();
 	}
 	error = NULL;
-	xcb_translate_coordinates_cookie_t tcookie = xcb_translate_coordinates(connection, this->handle, rootWindow, geometry->x, geometry->y);
+	xcb_translate_coordinates_cookie_t tcookie = xcb_translate_coordinates(connection, this->handle, rootWindow, 0, 0);
 	xcb_translate_coordinates_reply_t* translation = xcb_translate_coordinates_reply(connection, tcookie, &error);
 	if (error != NULL) {
 		free(error);

--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -586,7 +586,10 @@ void RecordThread() {
 							int16_t click_x = event->root_x;
 							int16_t click_y = event->root_y;
 							xcb_window_t hit = HitTest(click_x, click_y);
-							std::cout << "Clicked on window " << hit << std::endl;
+							IterateEvents(
+								[hit](const TrackedEvent& e){return e.type == WindowEventType::Click && e.window == hit;},
+								[](Napi::Env env, Napi::Function callback){callback.Call({});}
+							);
 						}
 						break;
 					}

--- a/src/appframe/alt1api.ts
+++ b/src/appframe/alt1api.ts
@@ -209,12 +209,12 @@ function subImageData(img: FlatImageData, x: number, y: number, w: number, h: nu
 }
 
 let getters: PropertyDescriptorMap = {
-	rsX: { get() { return getRsInfo().clientRect.x } },
-	rsY: { get() { return getRsInfo().clientRect.y } },
-	rsWidth: { get() { return getRsInfo().clientRect.width } },
-	rsHeight: { get() { return getRsInfo().clientRect.height } },
-	rsActive: { get() { return getRsInfo().active } },
-	rsLastActive: { get() { return (getRsInfo().active ? 0 : Date.now() - getRsInfo().lastBlurTime); } },
+	rsX: { get() { return getRsInfo().clientRect.x; } },
+	rsY: { get() { return getRsInfo().clientRect.y; } },
+	rsWidth: { get() { return getRsInfo().clientRect.width; } },
+	rsHeight: { get() { return getRsInfo().clientRect.height; } },
+	rsActive: { get() { return getRsInfo().active; } },
+	rsLastActive: { get() { return Date.now() - getRsInfo().lastActiveTime; } },
 	rsPing: { get() { return getRsInfo().ping; } },
 	rsScaling: { get() { return getRsInfo().scaling; } },
 	rsLinked: { get() { return true; } }, //can no longer open apps without rs

--- a/src/appframe/index.tsx
+++ b/src/appframe/index.tsx
@@ -4,7 +4,6 @@ import { useState, useLayoutEffect, useRef } from "react";
 import { render } from "react-dom";
 import { ipcRenderer, WebContents } from "electron";
 import * as remote from "@electron/remote";
-import classnames from "classnames";
 import type { RectLike } from "@alt1/base";
 
 import "./style.scss";
@@ -169,9 +168,16 @@ function clickThroughEffect(minimized: boolean, rc: RectLike, rootref: React.Mut
 				root.removeEventListener("mouseleave", handler);
 			}
 		} else {
-			// TODO: click-through on Linux using Shape API
+			thiswindow.window.setResizable(false);
+			const width = thiswindow.window.getSize()[0];
+			ipcRenderer.send("shape", thiswindow.nativeWindow.handle, [{x: width - 72, y: 0, width: 30, height: 12}, {x: width - 42, y: 0, width: 42, height: 14}]);
+		}
+	} else {
+		if (process.platform != "linux") {
 			thiswindow.window.setIgnoreMouseEvents(false);
+		} else {
+			ipcRenderer.send("unshape", thiswindow.nativeWindow.handle);
+			thiswindow.window.setResizable(true);
 		}
 	}
-	thiswindow.window.setIgnoreMouseEvents(false);
 }

--- a/src/appframe/index.tsx
+++ b/src/appframe/index.tsx
@@ -169,8 +169,14 @@ function clickThroughEffect(minimized: boolean, rc: RectLike, rootref: React.Mut
 			}
 		} else {
 			thiswindow.window.setResizable(false);
-			const width = thiswindow.window.getSize()[0];
-			ipcRenderer.send("shape", thiswindow.nativeWindow.handle, [{x: width - 72, y: 0, width: 30, height: 12}, {x: width - 42, y: 0, width: 42, height: 14}]);
+			if (rc) {
+				const [winx, winy] = thiswindow.window.getPosition();
+				const [winw, winh] = thiswindow.window.getSize();
+				ipcRenderer.send("shape", thiswindow.nativeWindow.handle, [{x: rc.x, y: rc.y, width: rc.width, height: rc.height}], 3);
+			} else {
+				const width = thiswindow.window.getSize()[0];
+				ipcRenderer.send("shape", thiswindow.nativeWindow.handle, [{x: width - 72, y: 0, width: 30, height: 12}, {x: width - 42, y: 0, width: 42, height: 14}], 0);
+			}
 		}
 	} else {
 		if (process.platform != "linux") {

--- a/src/main.ts
+++ b/src/main.ts
@@ -302,7 +302,7 @@ function initIpcApi() {
 		let state: RsClientState = {
 			active: wnd.rsClient.isActive,
 			clientRect: wnd.rsClient.window.getClientBounds(),
-			lastBlurTime: wnd.rsClient.lastBlurTime,
+			lastActiveTime: wnd.rsClient.lastActiveTime,
 			ping: 10,//TODO
 			scaling: 1,//TODO
 			captureMode: settings.captureMode

--- a/src/main.ts
+++ b/src/main.ts
@@ -339,11 +339,7 @@ function initIpcApi() {
 		wnd.rsClient.overlayCommands(wnd.appFrameId, commands);
 	});
 
-	ipcMain.on("shape", (e, wnd: BigInt, rects: Rectangle[], op: number) => {
-		native.setWindowShape(wnd, rects, op);
-	});
-
-	ipcMain.on("unshape", (e, wnd: BigInt) => {
-		native.unsetWindowShape(wnd);
+	ipcMain.on("shape", (e, wnd: BigInt, rects: Rectangle[]) => {
+		native.setWindowShape(wnd, rects);
 	});
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -317,7 +317,7 @@ function initIpcApi() {
 	});
 
 	ipcMain.handle("capturemulti", (e, rects: { [key: string]: Rectangle }) => {
-		let wnd = getManagedAppWindow(e.sender.id);;
+		let wnd = getManagedAppWindow(e.sender.id);
 		if (!wnd?.rsClient.window) { throw new Error("rs window not found"); }
 		return native.captureWindowMulti(wnd.rsClient.window.handle, settings.captureMode, rects);
 	});
@@ -334,5 +334,13 @@ function initIpcApi() {
 		//TODO errors here are not rethrown in app, just swallow and log them
 		if (!wnd?.rsClient.window) { throw new Error("rs window not found"); }
 		wnd.rsClient.overlayCommands(wnd.appFrameId, commands);
+	});
+
+	ipcMain.on("shape", (e, wnd: BigInt, rects: Rectangle[]) => {
+		native.setWindowShape(wnd, rects);
+	});
+
+	ipcMain.on("unshape", (e, wnd: BigInt) => {
+		native.unsetWindowShape(wnd);
 	});
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -336,8 +336,8 @@ function initIpcApi() {
 		wnd.rsClient.overlayCommands(wnd.appFrameId, commands);
 	});
 
-	ipcMain.on("shape", (e, wnd: BigInt, rects: Rectangle[]) => {
-		native.setWindowShape(wnd, rects);
+	ipcMain.on("shape", (e, wnd: BigInt, rects: Rectangle[], op: number) => {
+		native.setWindowShape(wnd, rects, op);
 	});
 
 	ipcMain.on("unshape", (e, wnd: BigInt) => {

--- a/src/native.ts
+++ b/src/native.ts
@@ -16,7 +16,7 @@ export var native: {
 	getClientBounds: (wnd: BigInt) => Rectangle,
 	getWindowTitle: (wnd: BigInt) => string,
 	setWindowParent: (wnd: BigInt, parent: BigInt) => void,
-	setWindowShape: (wnd: BigInt, rects: Rectangle[]) => void,
+	setWindowShape: (wnd: BigInt, rects: Rectangle[], op: number) => void,
 	unsetWindowShape: (wnd: BigInt) => void,
 
 	newWindowListener: <T extends keyof windowEvents>(wnd: BigInt, type: T, cb: windowEvents[T]) => void,

--- a/src/native.ts
+++ b/src/native.ts
@@ -16,8 +16,7 @@ export var native: {
 	getClientBounds: (wnd: BigInt) => Rectangle,
 	getWindowTitle: (wnd: BigInt) => string,
 	setWindowParent: (wnd: BigInt, parent: BigInt) => void,
-	setWindowShape: (wnd: BigInt, rects: Rectangle[], op: number) => void,
-	unsetWindowShape: (wnd: BigInt) => void,
+	setWindowShape: (wnd: BigInt, rects: Rectangle[]) => void,
 
 	newWindowListener: <T extends keyof windowEvents>(wnd: BigInt, type: T, cb: windowEvents[T]) => void,
 	removeWindowListener: <T extends keyof windowEvents>(wnd: BigInt, type: T, cb: windowEvents[T]) => void,

--- a/src/native.ts
+++ b/src/native.ts
@@ -16,6 +16,8 @@ export var native: {
 	getClientBounds: (wnd: BigInt) => Rectangle,
 	getWindowTitle: (wnd: BigInt) => string,
 	setWindowParent: (wnd: BigInt, parent: BigInt) => void,
+	setWindowShape: (wnd: BigInt, rects: Rectangle[]) => void,
+	unsetWindowShape: (wnd: BigInt) => void,
 
 	newWindowListener: <T extends keyof windowEvents>(wnd: BigInt, type: T, cb: windowEvents[T]) => void,
 	removeWindowListener: <T extends keyof windowEvents>(wnd: BigInt, type: T, cb: windowEvents[T]) => void,

--- a/src/rsinstance.ts
+++ b/src/rsinstance.ts
@@ -114,7 +114,7 @@ export class RsInstance extends TypedEmitter<RsInstanceEvents>{
 	overlayWindow: { browser: BrowserWindow, pin: OSWindowPin | null, stalledOverlay: { frameid: number, cmd: OverlayCommand[] }[] } | null;
 	activeRightclick: ActiveRightclick | null = null;
 	isActive = false;
-	lastBlurTime = 0;
+	lastActiveTime = 0;
 
 	constructor(rswindow: OSWindow) {
 		super();
@@ -151,6 +151,7 @@ export class RsInstance extends TypedEmitter<RsInstanceEvents>{
 
 	@boundMethod
 	async clientClicked() {
+		this.lastActiveTime = Date.now();
 		if (this.activeRightclick) {
 			this.activeRightclick.close();
 		}

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -6,7 +6,7 @@ export type Rectangle = { x: number, y: number, width: number, height: number };
 export type RsClientState = {
 	clientRect: Rectangle,
 	active: boolean,
-	lastBlurTime: number,
+	lastActiveTime: number,
 	ping: number,
 	scaling: number,
 	captureMode: CaptureMode


### PR DESCRIPTION
This PR adds the extensions `xcb-record` and `xcb-shape` as dependencies for building on Linux. It also makes use of them to add two features which were previously missing from Linux builds: mouse click events, and the click-through effect on minimized app windows. In other words, this PR makes us feature-complete on Linux.

This is a pretty big change and I've only been able to test it on my machine, so I'd appreciate you trying it out on at least one other Linux machine before merging. Open something like AFK warden and check that the lobby timer resets when you click the game, and that it doesn't reset when you click a different window, like one that's on top of the game for example. Also try clicking through minimized app windows and make sure you can interact with the game as normal, and doing that should also reset the lobby timer.