### PR TITLE
Update the tray menu when apps are installed

### DIFF
--- a/src/appconfig.ts
+++ b/src/appconfig.ts
@@ -1,4 +1,4 @@
-import { } from "./main";
+import { updateTray } from "./main";
 import { readJsonWithBOM, sameDomainResolve, UserError } from "./lib";
 import fetch from "node-fetch";
 import { Bookmark, settings } from "./settings";
@@ -58,8 +58,8 @@ export function installApp(url: URL, res: AppConfigImport) {
 		lastRect: null,
 		wasOpen: false
 	};
-	updateAppconfig(config, res);
 	settings.bookmarks.push(config);
+	updateAppconfig(config, res);
 	return config;
 }
 function updateAppconfig(prev: Bookmark, config: AppConfigImport) {
@@ -78,6 +78,7 @@ function updateAppconfig(prev: Bookmark, config: AppConfigImport) {
 	prev.defaultWidth = config.defaultWidth;
 	prev.defaultHeight = config.defaultHeight;
 	tryUpdateIcon(prev);
+	updateTray();
 }
 
 export async function identifyApp(url: URL) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,7 @@ process.chdir(__dirname);
 if (!app.requestSingleInstanceLock()) { app.exit(); }
 app.setAsDefaultProtocolClient(schemestring, undefined, [__non_webpack_require__.main!.filename]);
 handleSchemeArgs(process.argv);
-loadSettings();
+loadSettings(); // Cannot await on top-level, so if config is missing, default settings are loaded later
 remoteMain.initialize();
 
 app.on("before-quit", e => {
@@ -141,12 +141,7 @@ export class ManagedWindow {
 	}
 }
 
-function drawTray() {
-	if (!tray) {
-		tray = new Tray(alt1icon);
-		tray.on("click", e => tray!.popUpContextMenu());
-	}
-	tray.setToolTip("Alt1 Lite");
+export function updateTray() {
 	let menu: MenuItemConstructorOptions[] = [];
 	for (let app of settings.bookmarks) {
 		menu.push({
@@ -174,7 +169,16 @@ function drawTray() {
 	menu.push({ label: "Settings", click: showSettings });
 	menu.push({ label: "Exit", click: e => app.quit() });
 	let menuinst = Menu.buildFromTemplate(menu);
-	tray.setContextMenu(menuinst);
+	tray?.setContextMenu(menuinst);
+}
+
+function drawTray() {
+	if (!tray) {
+		tray = new Tray(alt1icon);
+		tray.on("click", e => tray!.popUpContextMenu());
+	}
+	tray.setToolTip("Alt1 Lite");
+	updateTray();
 }
 
 let settingsWnd: BrowserWindow | null = null;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -51,7 +51,7 @@ export var settings: UservarType<typeof checkSettings>
 
 export async function loadSettings() {
 	try {
-		let file = JSON.parse(fs.readFileSync("./config.json", "utf8"));
+		let file = JSON.parse(fs.readFileSync(configFile, "utf8"));
 		settings = checkSettings.load(file, { defaultOnError: true });
 	} catch (e) {
 		console.log("couldn't load config");


### PR DESCRIPTION
On first launch, apps aren't visible in the menu because the menu is created on launch, while the apps are fetched from the default config. This PR recreates the tray menu everytime an app is installed.

Will likely conflict with #17, but easy to fix when one or the other is merged.