### PR TITLE
Missing libprocps on Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm run ui
 ### Arch (pacman)
 
 ```console
-# pacman -S pkg-config libxcb xcb-util-wm procps-ng
+# pacman -S pkg-config libxcb xcb-util-wm procps-ng libprocps
 ```
 
 ### Debian/Ubuntu (apt)


### PR DESCRIPTION
Just noticed that the libprocps package was missing from the arch section.