### PR TITLE
Detect window classname rs2client.exe

### DIFF
--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -138,7 +138,7 @@ bool IsRsWindow(const xcb_window_t window) {
 			memcpy(buffer, xcb_get_property_value(replyProp), len);
 			// first is instance name, then class name - both null terminated. we want class name.
 			const char* classname = buffer + strlen(buffer) + 1;
-			if (strcmp(classname, "RuneScape") == 0 || strcmp(classname, "steam_app_1343400") == 0) {
+			if (strcmp(classname, "RuneScape") == 0 || strcmp(classname, "steam_app_1343400") == 0 || strcmp(classname, "rs2client.exe") == 0) {
 				auto replyTransient = xcb_get_property_reply(connection, cookieTransient, NULL);
 				if (replyTransient && xcb_get_property_value_length(replyTransient) == 0) {
 					free(replyProp);


### PR DESCRIPTION
After installing Jagex Launcher via Lutris and launching RuneScape, the game has the window classname `rs2client.exe`. This adds detection for that use case to the `IsRsWindow()` method.