### PR TITLE
Also check window title to support xwayland

### DIFF
--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -138,14 +138,14 @@ bool IsRsWindow(const xcb_window_t window) {
 			memcpy(buffer, xcb_get_property_value(replyProp), len);
 			// first is instance name, then class name - both null terminated. we want class name.
 			const char* classname = buffer + strlen(buffer) + 1;
-			if (strcmp(classname, "RuneScape") == 0 || strcmp(classname, "steam_app_1343400") == 0 || strcmp(classname, "rs2client.exe") == 0) {
+			if (strcmp(classname, "RuneScape") == 0 || strcmp(classname, "steam_app_1343400") == 0) {
 				auto replyTransient = xcb_get_property_reply(connection, cookieTransient, NULL);
 				if (replyTransient && xcb_get_property_value_length(replyTransient) == 0) {
 					std::cout << "Found client: " << classname << std::endl;
 					free(replyProp);
 					return true;
 				}
-			} else if (strcmp(classname, "steam_proton") == 0) {
+			} else if (strcmp(classname, "steam_proton") || strcmp(classname, "rs2client.exe") == 0) {
 				auto replyTransient = xcb_get_property_reply(connection, cookieTransient, NULL);
 				xcb_get_property_cookie_t cookie = xcb_get_property_unchecked(connection, 0, window, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 0, 100);
 				std::unique_ptr<xcb_get_property_reply_t, decltype(&free)> reply { xcb_get_property_reply(connection, cookie, NULL), &free };

--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -150,25 +150,9 @@ bool IsRsWindow(const xcb_window_t window) {
 					/* Covers both normal and compatibility mode (substring of RuneScape (compatibility mode) )*/
 					if (str_title.find("RuneScape") != std::string::npos) {
 						if (replyTransient && xcb_get_property_value_length(replyTransient) == 0) {
-							xcb_get_geometry_cookie_t geomCookie = xcb_get_geometry(connection, window);
-							xcb_get_geometry_reply_t* geomReply = xcb_get_geometry_reply(connection, geomCookie, NULL);
-							if (geomReply) {
-								uint16_t width = geomReply->width;
-								uint16_t height = geomReply->height;
-								free(geomReply);
-								if (width == 720 && height == 480) {
-									/* The launcher window doesn't actually get killed on closing, it still exists in xwayland invisibly (Also not visible to the wayland compositor, only to xwayland).
-									 * A workaround is to kill this window with xdotool if it matches this exact window size (it does not change) in for instance a .desktop file of the jagex launcher.
-									 * This native code could also possibly do this, but it's probably out of scope.
-									 * The native code has no other ways to identify it as the window's class and title are exactly the same as the actual game window.
-									 * */
-									std::cout << "Found RuneScape Launcher phantom window: " << width << "x" << height << "\n";
-								} else {
-									std::cout << "Found correct RuneScape window: " << str_title << std::endl;
-									free(replyProp);
-									return true;
-								}
-							}
+							std::cout << "Found correct RuneScape window: " << str_title << std::endl;
+							free(replyProp);
+							return true;
 						} else {
 							std::cout << "NonTransient window found: " << str_title << std::endl;
 						}

--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -147,7 +147,7 @@ bool IsRsWindow(const xcb_window_t window) {
 					int length = xcb_get_property_value_length(reply.get());
 					auto str_title = std::string(title, length);
 					/* Covers both normal and compatibility mode (substring of RuneScape (compatibility mode) )*/
-					if (str_title.find("RuneScape") != std::string::npos) {
+					if (str_title.compare(0, sizeof("RuneScape") - 1, "RuneScape") == 0) {
 						if (replyTransient && xcb_get_property_value_length(replyTransient) == 0) {
 							free(replyProp);
 							return true;

--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -138,7 +138,8 @@ bool IsRsWindow(const xcb_window_t window) {
 			memcpy(buffer, xcb_get_property_value(replyProp), len);
 			// first is instance name, then class name - both null terminated. we want class name.
 			const char* classname = buffer + strlen(buffer) + 1;
-			if (strcmp(classname, "RuneScape") == 0 || strcmp(classname, "steam_app_1343400") == 0 || strcmp(classname, "steam_proton") || strcmp(classname, "rs2client.exe") == 0) {
+			if (strcmp(classname, "RuneScape") == 0 || strcmp(classname, "steam_app_1343400") == 0 || strcmp(classname, "steam_proton") == 0 || strcmp(classname, "rs2client.exe") == 0) {
+				std::cout << "Found classname: " << classname << std::endl;
 				auto replyTransient = xcb_get_property_reply(connection, cookieTransient, NULL);
 				xcb_get_property_cookie_t cookie = xcb_get_property_unchecked(connection, 0, window, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 0, 100);
 				std::unique_ptr<xcb_get_property_reply_t, decltype(&free)> reply { xcb_get_property_reply(connection, cookie, NULL), &free };

--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -139,7 +139,6 @@ bool IsRsWindow(const xcb_window_t window) {
 			// first is instance name, then class name - both null terminated. we want class name.
 			const char* classname = buffer + strlen(buffer) + 1;
 			if (strcmp(classname, "RuneScape") == 0 || strcmp(classname, "steam_app_1343400") == 0 || strcmp(classname, "steam_proton") == 0 || strcmp(classname, "rs2client.exe") == 0) {
-				std::cout << "Found classname: " << classname << std::endl;
 				auto replyTransient = xcb_get_property_reply(connection, cookieTransient, NULL);
 				xcb_get_property_cookie_t cookie = xcb_get_property_unchecked(connection, 0, window, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 0, 100);
 				std::unique_ptr<xcb_get_property_reply_t, decltype(&free)> reply { xcb_get_property_reply(connection, cookie, NULL), &free };
@@ -150,14 +149,11 @@ bool IsRsWindow(const xcb_window_t window) {
 					/* Covers both normal and compatibility mode (substring of RuneScape (compatibility mode) )*/
 					if (str_title.find("RuneScape") != std::string::npos) {
 						if (replyTransient && xcb_get_property_value_length(replyTransient) == 0) {
-							std::cout << "Found correct RuneScape window: " << str_title << std::endl;
 							free(replyProp);
 							return true;
 						} else {
 							std::cout << "NonTransient window found: " << str_title << std::endl;
 						}
-					} else {
-						std::cout << "Wrong title: " << str_title << std::endl;
 					}
 				}
 

--- a/native/os_x11_linux.cc
+++ b/native/os_x11_linux.cc
@@ -138,14 +138,7 @@ bool IsRsWindow(const xcb_window_t window) {
 			memcpy(buffer, xcb_get_property_value(replyProp), len);
 			// first is instance name, then class name - both null terminated. we want class name.
 			const char* classname = buffer + strlen(buffer) + 1;
-			if (strcmp(classname, "RuneScape") == 0 || strcmp(classname, "steam_app_1343400") == 0) {
-				auto replyTransient = xcb_get_property_reply(connection, cookieTransient, NULL);
-				if (replyTransient && xcb_get_property_value_length(replyTransient) == 0) {
-					std::cout << "Found client: " << classname << std::endl;
-					free(replyProp);
-					return true;
-				}
-			} else if (strcmp(classname, "steam_proton") || strcmp(classname, "rs2client.exe") == 0) {
+			if (strcmp(classname, "RuneScape") == 0 || strcmp(classname, "steam_app_1343400") == 0 || strcmp(classname, "steam_proton") || strcmp(classname, "rs2client.exe") == 0) {
 				auto replyTransient = xcb_get_property_reply(connection, cookieTransient, NULL);
 				xcb_get_property_cookie_t cookie = xcb_get_property_unchecked(connection, 0, window, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 0, 100);
 				std::unique_ptr<xcb_get_property_reply_t, decltype(&free)> reply { xcb_get_property_reply(connection, cookie, NULL), &free };
@@ -153,7 +146,7 @@ bool IsRsWindow(const xcb_window_t window) {
 					char* title = reinterpret_cast<char*>(xcb_get_property_value(reply.get()));
 					int length = xcb_get_property_value_length(reply.get());
 					auto str_title = std::string(title, length);
-					/* Covers both normal and compatibility mode */
+					/* Covers both normal and compatibility mode (substring of RuneScape (compatibility mode) )*/
 					if (str_title.find("RuneScape") != std::string::npos) {
 						if (replyTransient && xcb_get_property_value_length(replyTransient) == 0) {
 							xcb_get_geometry_cookie_t geomCookie = xcb_get_geometry(connection, window);
@@ -163,10 +156,10 @@ bool IsRsWindow(const xcb_window_t window) {
 								uint16_t height = geomReply->height;
 								free(geomReply);
 								if (width == 720 && height == 480) {
-									/* The launcher window doesn't actually get killed on closing, it still exists in xwayland invisibly (Also not visible to the compositor, only to xwayland).
+									/* The launcher window doesn't actually get killed on closing, it still exists in xwayland invisibly (Also not visible to the wayland compositor, only to xwayland).
 									 * A workaround is to kill this window with xdotool if it matches this exact window size (it does not change) in for instance a .desktop file of the jagex launcher.
 									 * This native code could also possibly do this, but it's probably out of scope.
-									 * The window has few other ways to identify it as the window's class and title are exactly the same.
+									 * The native code has no other ways to identify it as the window's class and title are exactly the same as the actual game window.
 									 * */
 									std::cout << "Found RuneScape Launcher phantom window: " << width << "x" << height << "\n";
 								} else {


### PR DESCRIPTION
in xwayland, wine for some reason opens a window that's invisible to wayland, and is invisible to the eye as well. Only X can detect the window, and that causes alt1 to latch onto more than one window when only checking the windows' classnames. This PR aims to add checking of the window title as well.